### PR TITLE
PROD commits.to for traefik-outer.turkey.local

### DIFF
--- a/apps/production/routers/commits-to-ingressroute.yaml
+++ b/apps/production/routers/commits-to-ingressroute.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: commits-to-insecure
+  namespace: traefik-production
+spec:
+  entryPoints:
+    - web
+  routes:
+  - match: Host(`commits.to`,`giovanni.commits.to`,`nwinter.commits.to`,`patrick.commits.to`,`thameera.commits.to`,`madge.commits.to`,`xenocid.commits.to`,`alok.commits.to`,`luke.commits.to`,`eugeniobruno.commits.to`,`arti.commits.to`,`brian.commits.to`,`michael.commits.to`,`chris.commits.to`,`forrest.commits.to`,`byorgey.commits.to`,`az.commits.to`,`sergii.commits.to`,`kim.commits.to`,`edyson.commits.to`,`bee.commits.to`,`max.commits.to`,`kevin.commits.to`,`philip.commits.to`,`alex.commits.to`,`aian.commits.to`,`mbork.commits.to`,`shanaqui.commits.to`,`martin.commits.to`,`cole.commits.to`,`dan.commits.to`,`alys.commits.to`,`clive.commits.to`,`dreev.commits.to`,`jordan.commits.to`,`clarissa.commits.to`,`mary.commits.to`,`echodaniel.commits.to`,`adam.commits.to`,`elviejo79.commits.to`,`jade.commits.to`,`jay.commits.to`,`mike.commits.to`,`kb.commits.to`,`nick.commits.to`)
+    kind: Rule
+    services:
+    - name: commitsto-alpha-x-commitsto-alpha-x-hephy-stg
+      namespace: vcluster-hephy-stg-turkey-local
+      port: 80
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: commits-to
+  namespace: traefik-production
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - match: Host(`commits.to`,`giovanni.commits.to`,`nwinter.commits.to`,`patrick.commits.to`,`thameera.commits.to`,`madge.commits.to`,`xenocid.commits.to`,`alok.commits.to`,`luke.commits.to`,`eugeniobruno.commits.to`,`arti.commits.to`,`brian.commits.to`,`michael.commits.to`,`chris.commits.to`,`forrest.commits.to`,`byorgey.commits.to`,`az.commits.to`,`sergii.commits.to`,`kim.commits.to`,`edyson.commits.to`,`bee.commits.to`,`max.commits.to`,`kevin.commits.to`,`philip.commits.to`,`alex.commits.to`,`aian.commits.to`,`mbork.commits.to`,`shanaqui.commits.to`,`martin.commits.to`,`cole.commits.to`,`dan.commits.to`,`alys.commits.to`,`clive.commits.to`,`dreev.commits.to`,`jordan.commits.to`,`clarissa.commits.to`,`mary.commits.to`,`echodaniel.commits.to`,`adam.commits.to`,`elviejo79.commits.to`,`jade.commits.to`,`jay.commits.to`,`mike.commits.to`,`kb.commits.to`,`nick.commits.to`)
+    kind: Rule
+    services:
+    - name: commitsto-alpha-x-commitsto-alpha-x-hephy-stg
+      namespace: vcluster-hephy-stg-turkey-local
+      port: 80
+  tls:
+    certResolver: myresolver


### PR DESCRIPTION
This will provision a Challenge and Order, (the TLS cert is kept on the server with the others from this directory)

$ k get pvc
NAME          STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
traefik-tls   Bound    pvc-406d3d10-8657-4ca4-a002-c0d6a4ccaf97   1Gi        RWO            local-path     27d

It's renewed automatically